### PR TITLE
Thread Pools

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [clj-http "2.0.0"]
                  [org.clojure/tools.cli "0.3.3"]
-                 [org.clojure/data.json "0.2.6"]]
+                 [org.clojure/data.json "0.2.6"]
+                 [com.climate/claypoole "1.1.0"]]
   :main frmr.dstt
   :aot [frmr.dstt]
 

--- a/src/frmr/dstt.clj
+++ b/src/frmr/dstt.clj
@@ -80,15 +80,15 @@
           request-futures (map #(issue-timed-request test-start-time-ns request-invoker % handler network-pool) request-delays)
           results (doall (cp/pmap cpu-pool deref (doall request-futures)))
           grouped-result-categories (partition (count results) (apply interleave results))
-          average-per-category (mapv #(apply-to-numbers % average) grouped-result-categories)
-          min-per-category (mapv #(apply-to-numbers % (fn [x] (apply min x))) grouped-result-categories)
-          max-per-category (mapv #(apply-to-numbers % (fn [x] (apply max x))) grouped-result-categories)
-          stddev-per-category (mapv #(apply-to-numbers % standard-deviation) grouped-result-categories)]
-      {"Averages" average-per-category
-       "Minimums" min-per-category
-       "Maximums" max-per-category
-       "StandardDeviations" stddev-per-category
-       "RawResults" results})))
+          average-per-category (cp/pmap cpu-pool #(apply-to-numbers % average) grouped-result-categories)
+          min-per-category (cp/pmap cpu-pool #(apply-to-numbers % (fn [x] (apply min x))) grouped-result-categories)
+          max-per-category (cp/pmap cpu-pool #(apply-to-numbers % (fn [x] (apply max x))) grouped-result-categories)
+          stddev-per-category (cp/pmap cpu-pool #(apply-to-numbers % standard-deviation) grouped-result-categories)]
+      {"Averages" (vec average-per-category)
+       "Minimums" (vec min-per-category)
+       "Maximums" (vec max-per-category)
+       "StandardDeviations" (vec stddev-per-category)
+       "RawResults" (vec results)})))
 
 (defn- select-function-for-http-method
  [http-method]

--- a/src/frmr/dstt.clj
+++ b/src/frmr/dstt.clj
@@ -213,7 +213,8 @@
 
             request-options (merge {:headers http-headers}
                                    (some-> http-body parse-body)
-                                   {:follow-redirects false})
+                                   {:follow-redirects false
+                                    :throw-exceptions false})
             request-invoker (build-request-invoker http-method url request-options)
 
             [parsed-handler custom-handler-name] (if-not (nil? handler)

--- a/test/frmr/dstt_test.clj
+++ b/test/frmr/dstt_test.clj
@@ -24,7 +24,7 @@
   (let [last-handler-string (atom "")
         test-request-invoker (fn [] {:status 200 :body "Bacon123"})
         test-handler (fn [_ body] (reset! last-handler-string body))
-        future (issue-timed-request test-request-invoker 0 test-handler)
+        future (issue-timed-request (System/nanoTime) test-request-invoker 0 test-handler :builtin)
         _ @future]
     (is (= @last-handler-string {:status 200, :body "Bacon123"}) "Handler receives body content.")))
 


### PR DESCRIPTION
Increase our support for a large number of requests by leveraging claypoole to control our thread pool for requests instead of using Clojure's built in future and thread pool implementation.
